### PR TITLE
Fix CORS issue with Google Apps Script Web App submission

### DIFF
--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -349,19 +349,19 @@ const submitForm = async () => {
 	formData.append("userId", form.value.userId);
 	formData.append("hashId", form.value.hashId);
 
+	// Google Apps Script 的 Web App (/exec) 不會回傳 Access-Control-Allow-Origin，
+	// 瀏覽器一律會擋掉回應內容（即使伺服器端已經成功寫入資料），
+	// 因此改用 no-cors：請求仍會送達並執行，只是拿不到回應內容可供判斷成功與否。
 	fetch(SubmitwebAppUrl.value, {
 	  method: "POST",
+	  mode: "no-cors",
 	  headers: {
 		"Content-Type": "application/x-www-form-urlencoded",
 	  },
 	  body: formData.toString(), // 使用 URL 編碼格式
 	})
-	  .then(response => {
-		if (response.ok) {
-		  window.location.href = "finish.html";
-		} else {
-		  throw new Error("提交過程中出現錯誤");
-		}
+	  .then(() => {
+		window.location.href = "finish.html";
 	  })
 	  .catch(error => {
 		alert(error.message);

--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -214,6 +214,7 @@ const License = ref(false);
 
 const termsAccepted = computed(() => {
 	return (
+		SubmitwebAppUrl.value !== "" &&
 		form.value.ruleCheck !== "" &&
 		form.value.name.trim() !== "" &&
 		form.value.date !== "" &&
@@ -239,22 +240,25 @@ onMounted(() => {
 })
 
 // ✅ 把 fetch 移到獨立的 async 函數
-async function loadEnvData() {
+async function loadEnvData(retriesLeft = 2) {
   try {
     const baseUrl = import.meta.env.BASE_URL; // 取得專案的根路徑
-    const response = await fetch(`${baseUrl}env.json`); // ✅ 正確取得 env.json
+    const response = await fetch(`${baseUrl}env.json`, { cache: "no-store" }); // ✅ 正確取得 env.json，避免瀏覽器快取舊資料
     if (!response.ok) {
       throw new Error("Failed to fetch env.json");
     }
     const data = await response.json();
     formTitle.value = data.TitleDate + '，桃園TRPG推廣活動報名表'; // 設定表單標題
 	SubmitwebAppUrl.value = data.webAppUrl;
-	
+
 	setTimeout(() => {
       EventDate1.value = data.ThisEventDate; // ✅ 延遲設定，避免 Vue 預選 radio
     }, 100);
   } catch (error) {
     console.error("Error loading env.json:", error);
+	if (retriesLeft > 0) {
+	  setTimeout(() => loadEnvData(retriesLeft - 1), 1000);
+	}
   }
 }
 
@@ -324,8 +328,12 @@ const ageOptions = [
 
 const submitForm = async () => {
   console.log("提交表單", form.value);
-  alert("表單提交成功");
-  
+
+  if (!SubmitwebAppUrl.value) {
+	alert("表單尚未載入完成，請重新整理頁面後再試一次");
+	return;
+  }
+
   form.value.userId = getCookie("userId");
   if (!form.value.userId) 
   {
@@ -361,10 +369,11 @@ const submitForm = async () => {
 	  body: formData.toString(), // 使用 URL 編碼格式
 	})
 	  .then(() => {
+		alert("表單提交成功");
 		window.location.href = "finish.html";
 	  })
 	  .catch(error => {
-		alert(error.message);
+		alert("提交過程中出現錯誤：" + error.message);
 	  });
 
 


### PR DESCRIPTION
## Summary
Updated the form submission logic to handle CORS limitations when submitting to Google Apps Script Web Apps. Since Google Apps Script's `/exec` endpoint doesn't return `Access-Control-Allow-Origin` headers, the browser blocks the response even when the server-side operation succeeds. This change implements a workaround using the `no-cors` fetch mode.

## Key Changes
- Added `mode: "no-cors"` to the fetch request to allow the request to be sent and executed on the server without requiring CORS headers
- Simplified the response handling since the response body is inaccessible in no-cors mode
- Removed the `response.ok` check and error handling logic, as the response cannot be inspected
- Added explanatory comments (in Traditional Chinese) documenting the CORS limitation and the rationale for using no-cors mode
- Changed the `.then()` handler to always redirect to "finish.html" upon request completion, assuming successful server-side execution

## Implementation Details
With `mode: "no-cors"`, the fetch request will still reach the Google Apps Script endpoint and execute the server-side logic, but the browser will not allow JavaScript to inspect the response. This is an acceptable trade-off since the primary goal is to ensure data is written to the backend, and the redirect to the finish page serves as user confirmation of submission.

https://claude.ai/code/session_01YVqdsQApLyChX9iADkAXS5